### PR TITLE
Update jellyfish-environment dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,11 +99,11 @@
       }
     },
     "@balena/jellyfish-environment": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-0.0.4.tgz",
-      "integrity": "sha512-oRspbXEsHEM0TQi+a3q9/TiISH4HxwvGI3Nyxhu2NSg0TJqG6/LzI0wXJQOG5m11+GV6nC+mJein4iorSeDN/w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-1.0.0.tgz",
+      "integrity": "sha512-PVisO3jGwlu/2i8PxVnLQZcBAsMzBU9hcCDBGDqjPr53I0AlJf1oBLsGhlwerCchZgGoJIpWUaE/5lAPNlf7tg==",
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.19"
       }
     },
     "@concordance/react": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@balena/jellyfish-environment": "0.0.4",
+    "@balena/jellyfish-environment": "^1.0.0",
     "request": "^2.88.2",
     "request-promise": "^4.2.5"
   },


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Update `@balena/jellyfish-environment` dependency to `1.0.0` so we can use the new mail environment variables changes.
See https://github.com/product-os/jellyfish-environment/pull/4