### PR TITLE
Bump jellyfish-environment to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,9 +99,9 @@
       }
     },
     "@balena/jellyfish-environment": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-1.0.3.tgz",
-      "integrity": "sha512-88O3YeiRLq95xChxwe35SWXIL9ydyhI6toGCw6WjOsokdmrU3es5olPNgYYUjiFDsg03TEcBw8lBe/UnZVoJyw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/jellyfish-environment/-/jellyfish-environment-2.0.0.tgz",
+      "integrity": "sha512-eXnEmuw6gzPu4ULixu2h0QRwMBwkkUAYSD1xUCxk2vEF2xKnCdadGdqgGeCNSwQnxa7NLzu545Al7NXY25qRSw==",
       "requires": {
         "lodash": "^4.17.19"
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@balena/jellyfish-environment": "^1.0.0",
+    "@balena/jellyfish-environment": "^2.0.0",
     "request": "^2.88.2",
     "request-promise": "^4.2.5"
   },


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Bump `@balena/jellyfish-environment` to `2.0.0` to take advantage of this change: https://github.com/product-os/jellyfish-environment/pull/14